### PR TITLE
Make bot string template easier to read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "indoc"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05a0bd019339e5d968b37855180087b7b9d512c5046fbd244cf8c95687927d6e"
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +72,8 @@ name = "squiddy"
 version = "0.1.0"
 dependencies = [
  "convert_case",
+ "indoc",
+ "itertools",
  "serde",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 
 [dependencies]
 convert_case = "0.5.0"
-toml = "0.5"
+indoc = "1.0.6"
+itertools = "0.10.3"
 serde = { version = "1.0", features = ["derive"] }
+toml = "0.5"

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,4 +1,6 @@
 use convert_case::{Case, Casing};
+use indoc::formatdoc;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use crate::projects::Author;
@@ -24,47 +26,49 @@ pub struct Bot {
 
 impl Bot {
     pub fn to_markdown(&self) -> String {
-        let mut markdown = String::new();
-        markdown.push_str("---\n");
-        markdown.push_str(&format!("layout: {}\n", self.layout));
-        markdown.push_str(&format!("title: {}\n", self.title));
-        markdown.push_str("categories:\n - bot\n");
-        markdown.push_str(&format!("description: {}\n", self.description));
-        markdown.push_str("author:");
-        for author in &self.authors {
-            markdown.push_str(&format!(
-                " {} {},",
-                author.name,
-                author.matrix_id.clone().unwrap_or_else(|| "".to_string())
-            ));
-        }
-        markdown.pop();
-        markdown.push('\n');
-        markdown.push_str(&format!("maturity: {}\n", self.maturity));
-        markdown.push_str(&format!("language: {}\n", self.language));
-        markdown.push_str(&format!("license: {}\n", self.license));
-        if let Some::<String>(repository) = &self.repository {
-            markdown.push_str(&format!("repo: {}\n", repository));
-        }
-        if let Some::<String>(home) = &self.home {
-            markdown.push_str(&format!("home: {}\n", home));
-        }
-        if let Some::<String>(screenshot) = &self.screenshot {
-            markdown.push_str(&format!("screenshot: {}\n", screenshot));
-        }
-        if let Some::<String>(icon) = &self.icon {
-            markdown.push_str(&format!("thumbnail: {}\n", icon));
-        }
-        if let Some::<String>(room) = &self.room {
-            markdown.push_str(&format!("room: \"{}\"\n", room));
-        }
-        markdown.push_str(&format!("featured: {}\n", self.featured));
-        if let Some::<i32>(sort_order) = self.sort_order {
-            markdown.push_str(&format!("sort_order: {}\n", sort_order));
-        }
-        markdown.push_str(&format!("---\n{}\n", self.full_description));
+        let layout = &self.layout;
+        let title = &self.title;
+        let description = &self.description;
+        let authors = self
+            .authors
+            .iter()
+            .map(|a| format!("{} {}", a.name, a.matrix_id.clone().unwrap_or_default()))
+            .format(", ");
+        let maturity = &self.maturity;
+        let language = &self.language;
+        let license = &self.license;
+        let featured = &self.featured;
 
-        markdown
+        let optional_fields = [
+            self.repository.as_ref().map(|r| format!("repo: {r}")),
+            self.home.as_ref().map(|h| format!("home: {h}")),
+            self.screenshot.as_ref().map(|s| format!("screenshot: {s}")),
+            self.icon.as_ref().map(|i| format!("thumbnail: {i}")),
+            self.room.as_ref().map(|r| format!("room: {r}")),
+            self.sort_order.as_ref().map(|o| format!("sort_order: {o}")),
+        ]
+        .iter()
+        .flatten()
+        .join("\n");
+
+        let full_description = &self.full_description;
+
+        formatdoc! {"
+            ---
+            layout: {layout}
+            title: {title}
+            categories:
+             - bot
+            description: {description}
+            author: {authors}
+            maturity: {maturity}
+            language: {language}
+            license: {license}
+            featured: {featured}
+            {optional_fields}
+            ---
+            {full_description}
+        "}
     }
 
     pub fn filename(&self) -> String {


### PR DESCRIPTION
As written, this has the small downside that if none of the optional fields are set, there's an unnecessary newline before the second `---` line. This could be avoided, but I wasn't sure whether it would be much of a problem